### PR TITLE
Add support for Emoji

### DIFF
--- a/Example/Tests/MarkyMarkContentfulIntegrationTests.swift
+++ b/Example/Tests/MarkyMarkContentfulIntegrationTests.swift
@@ -168,6 +168,17 @@ class MarkyMarkContentfulIntegrationTests: XCTestCase {
         XCTAssert((markDownItems[0]).markDownItems![4] is ImageMarkDownItem)
     }
 
+    func testEmojiWorks() {
+        let emojiString = "This is an emoji 👍"
+
+        // Act
+        let markDownItems = sut.parseMarkDown(emojiString)
+
+        // Assert
+        XCTAssert(markDownItems[0] is ParagraphMarkDownItem)
+        XCTAssert(markDownItems[0].content == emojiString)
+    }
+
     func testParsingMarkDownPerformance() {
         let markDownString = "# Headers\n---\n# Header 1\n## Header 2\n### Header 3\n#### Header 4\n##### Header 5\n###### Header 6\n\n# Lists\n---\n## Ordered list\n1. Number 1\n2. Number 2\n3. Number 3\n5. Number 4\n  1. Nested 1\n  2. Nested 2\n6. Number 5\n---\n## Unordered list\n- Item 1\n- Item 2\n- Item 3\n  - Nested item 1\n  - ~~Nested item 2~~\n    - Subnested it'em 1\n    - Subnested it'em 2\n      - Subsubnest'ed item 1\n      - Subsubnest'ed item 2 [Velit](https://m2mobi.com)\n      - Subsubnes'ted item 3 *(with single **space**)*\n---\n## Combo\n1. Ordered 1\n2. Ordered 2\n  - Unordered 1\n  - Unordered 2\n  - Nested unorder'ed 1\n  - Nested unorder'ed 2\n    1. Subnested o'rdered 1\n    2. Subnested o'rdered 2\n\n# Images\n---\n![My Apple](http://images.apple.com/apple-events/static/apple-events/october-2013/video/poster_large.jpg)\n\n# Paragraphs\nLorem ipsum *dolor* sit amet, __consectetur__ adipiscing elit. Proin ***aliquet vulputate*** diam. Duis sodales ~~sapien~~ quis ***elementum* posuere**. Duis quam lectus, posueresed  [~~pellentesqueaauctor~~](https://m2mobi.com) eu [Velit](https://m2mobi.com).\n---\n## Quotes\n> MarkDown is awesome\n> Seriously..\n\n## Links\n[This is a test link](https://m2mobi.com)\nInline links are also possible, click [here](https://m2mobi.com)\n# Code\n---\n\n```\n@Override\nOn *multiple* lines\n```\n\n``` @Override ```\n\nOr maybe in line `@Override`"
 

--- a/Example/markymark/markdown.txt
+++ b/Example/markymark/markdown.txt
@@ -54,7 +54,7 @@ c. Number 3
 Inline image ![Apple logo](appleLogo) Apple logo ![Apple logo](appleLogoSmall)
 
 # Paragraphs
-Lorem ipsum *dolor* sit amet, __consectetur__ adipiscing elit. Proin ***aliquet vulputate*** diam. Duis sodales ~~sapien~~ quis ***elementum* posuere**. Duis quam lectus, posueresed  [~~pellentesqueaauctor~~](https://m2mobi.com) eu [Velit](https://m2mobi.com).
+Lorem ipsum *dolor* sit amet, __consectetur__ adipiscing elit. Proin ***aliquet vulputate*** diam. Emoji 🤘. Duis sodales ~~sapien~~ quis ***elementum* posuere**. Duis quam lectus, posueresed  [~~pellentesqueaauctor~~](https://m2mobi.com) eu [Velit](https://m2mobi.com).
 ---
 ## Quotes
 > MarkDown is awesome

--- a/markymark/Classes/Extensions/String+extensions.swift
+++ b/markymark/Classes/Extensions/String+extensions.swift
@@ -14,9 +14,10 @@ extension String {
     }
 
     func subString(_ range:NSRange) -> String {
-        let startIndex = self.characters.index(self.startIndex, offsetBy: range.location)
-        let endIndex = self.characters.index(self.startIndex, offsetBy: range.getLocationEnd())
-        return String(self[startIndex..<endIndex])
+        guard let range = Range(range, in: self) else { return "" }
+        let startIndex = self.distance(from: self.startIndex, to: range.lowerBound)
+        let endIndex = self.distance(from: self.startIndex, to: range.upperBound)
+        return subString(startIndex, endIndex)
     }
 
     func subStringWithExpression(_ expression:NSRegularExpression, ofGroup group:Int) -> String {


### PR DESCRIPTION
This commit will also address issue #30.

The way NSRange and NSString work is very different from String and Range. Generally speaking, we should never mixed them. This PR addresses that problem where we tried to use NSRange with String.

As an example, "😀" will return 2 when we use `NSString length`. However, "😀" will return 1 when we use `String.characters.count`.

