### PR TITLE
Change access identifiers for ImageMarkDownItem and TextAttachment

### DIFF
--- a/markymark/Classes/Layout Builders/AttributedString/Block Builders/Inline/TextAttachment.swift
+++ b/markymark/Classes/Layout Builders/AttributedString/Block Builders/Inline/TextAttachment.swift
@@ -9,9 +9,9 @@
 import Foundation
 import UIKit
 
-class TextAttachment: NSTextAttachment {
+public class TextAttachment: NSTextAttachment {
 
-    override func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
+    override public func attachmentBounds(for textContainer: NSTextContainer?, proposedLineFragment lineFrag: CGRect, glyphPosition position: CGPoint, characterIndex charIndex: Int) -> CGRect {
 
         var imageSize = CGSize()
 

--- a/markymark/Classes/MarkDown Items/ImageMarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/ImageMarkDownItem.swift
@@ -7,8 +7,8 @@ import Foundation
 
 open class ImageMarkDownItem : MarkDownItem {
 
-    let file:String
-    let altText:String
+    public let file:String
+    public let altText:String
     
     init(lines: [String], file: String, altText:String) {
         self.file = file


### PR DESCRIPTION
Fixes #38 