### PR TITLE
Debug regex for ImageRule

### DIFF
--- a/markymark/Classes/Rules/Inline/ImageRule.swift
+++ b/markymark/Classes/Rules/Inline/ImageRule.swift
@@ -8,7 +8,7 @@ import Foundation
 class ImageRule : InlineRegexRule {
 
     /// Example: ![Alt text](image.png)
-    var expression = NSRegularExpression.expressionWithPattern("(!\\p{Z}{0,1})\\[{0,1}(.+?)\\]\\({1}(.+?)\\)")
+    var expression = NSRegularExpression.expressionWithPattern("!\\[([^]]*)\\]\\(([^]]+)\\)")
 
     func createMarkDownItemWithLines(_ lines:[String]) -> MarkDownItem {
 


### PR DESCRIPTION
The regex for `ImageRule` was broken. It would take any `!` as the start of an inline image even if there was no image present in the markdown text if there was a regular link later in the same string.

i.e. this was breaking and being rendered as an image: "Congratulations! Here is some text, head over to the [Example site](https://www.example.com/)"


I've fixed the regex. You can test with the following string [here](https://regexr.com/)

proper regex: `!\[([^]]*)\]\(([^]]+)\)`
proper regex with extra escapes for swift strings: `!\\[([^]]*)\\]\\(([^]]+)\\)`
test string:
"Congratulations! Here is some text, head over to the [Example site](https://www.example.com/) ![Alt text](image.png) or [contact support](https://www.example.com/support/).


![Alt text](image.png)
![](image.png)
![Alt text]()
a
"