### PR TITLE
Explicit typing for metrics in containerView to avoid 'too complex'

### DIFF
--- a/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
+++ b/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
@@ -20,7 +20,7 @@ class ContainerView : UIView {
 
         let views = ["view" : view ]
 
-        let metrics = [
+        let metrics: [String: CGFloat] = [
             "top" : spacing?.top ?? 0,
             "left" : spacing?.left ?? 0,
             "bottom" : spacing?.bottom ?? 0,


### PR DESCRIPTION
<img width="1076" alt="screen shot 2018-02-13 at 13 11 25" src="https://user-images.githubusercontent.com/3635249/36149662-e18c9ee2-10c0-11e8-826d-f9a420a72523.png">
