### PR TITLE
Change to DefaultStyling structure to allow subclassing

### DIFF
--- a/markymark/Classes/Styling/DefaultStyling.swift
+++ b/markymark/Classes/Styling/DefaultStyling.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public struct DefaultStyling: Styling {
+open class DefaultStyling: Styling {
 
     fileprivate var extraStyling: [ItemStyling] = []
 
@@ -22,12 +22,30 @@ public struct DefaultStyling: Styling {
     public var inlineCodeBlockStyling = InlineCodeStyling()
     public var quoteStyling = QuoteStyling()
 
-    public mutating func addStyling(_ styling:ItemStyling) {
+    private var defaultStyling: [ItemStyling] {
+        return [
+            paragraphStyling,
+            italicStyling,
+            boldStyling,
+            headingStyling,
+            strikeThroughStyling,
+            listStyling,
+            imageStyling,
+            linkStyling,
+            horizontalLineStyling,
+            codeBlockStyling,
+            inlineCodeBlockStyling,
+            quoteStyling
+        ]
+    }
+
+    public func addStyling(_ styling:ItemStyling) {
         extraStyling.append(styling)
     }
 
+
     public var itemStylingRules: [ItemStyling] {
-        return extraStyling + collectStylingRules()
+        return extraStyling + defaultStyling
     }
 
     public init(){}

--- a/markymark/Classes/Styling/Protocols/Styling.swift
+++ b/markymark/Classes/Styling/Protocols/Styling.swift
@@ -21,16 +21,6 @@ extension Styling {
 
         return EmptyItemStyling()
     }
-
-    public var itemStylingRules: [ItemStyling] {
-        return collectStylingRules()
-    }
-
-    /// Collects all ItemStyling properties of the instance by using reflection
-
-    public func collectStylingRules() -> [ItemStyling] {
-        return Mirror(reflecting: self).children.flatMap { $0.value as? ItemStyling }
-    }
 }
 
 struct EmptyItemStyling: ItemStyling {


### PR DESCRIPTION
Made DefaultStyling an open class instead of a struct to allow subclassing.

Breaking change required:
- Removed the public extension on the protocol Styling.
- Replaced the mirror reflecting self with a computed property