### PR TITLE
Make markymark extension safe

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - markymark (7.1)
+  - markymark (8.0.0)
 
 DEPENDENCIES:
   - markymark (from `../`)
 
 EXTERNAL SOURCES:
   markymark:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  markymark: 2dbd0f000579b1992d0e6355d5cdd83b097d03f7
+  markymark: 5005e9274e5646dd7b35e60c12be631c259d284f
 
 PODFILE CHECKSUM: 702819c9a9352a2969fd49865aabe1f21e7c3404
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/Example/markymark.xcodeproj/project.pbxproj
+++ b/Example/markymark.xcodeproj/project.pbxproj
@@ -308,7 +308,6 @@
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
 				F220BF3FD9625FD67595F183 /* [CP] Embed Pods Frameworks */,
-				4536D5F2E1F7AC6E6B2E238E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -328,7 +327,6 @@
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
 				029A2E5D6800056D702BE822 /* [CP] Embed Pods Frameworks */,
-				7789EB477652F3880BD14E09 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -439,36 +437,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-markymark_Tests/Pods-markymark_Tests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4536D5F2E1F7AC6E6B2E238E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-markymark_Example/Pods-markymark_Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7789EB477652F3880BD14E09 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-markymark_Tests/Pods-markymark_Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		D70756FE8E6C87A920EAB880 /* [CP] Check Pods Manifest.lock */ = {

--- a/markymark.podspec
+++ b/markymark.podspec
@@ -13,6 +13,6 @@ Marky Mark is a parser written in Swift that converts markdown into native views
 
   s.ios.deployment_target = '8.0'
 
-s.source_files = 'markymark/Classes/**/*{.swift}'
+  s.source_files = 'markymark/Classes/**/*.{swift,h,m}'
 
 end

--- a/markymark/Classes/Layout Builders/UIView/Views/AttributedInteractiveLabel.swift
+++ b/markymark/Classes/Layout Builders/UIView/Views/AttributedInteractiveLabel.swift
@@ -51,7 +51,7 @@ open class AttributedInteractiveLabel: UILabel {
 
         let locationInView = tapGesture.location(in: view)
         if let url = getUrlAtLocationInView(locationInView) {
-            UIApplication.shared.openURL(url)
+            URLOpener().open(url)
         }
 
     }

--- a/markymark/Classes/Layout Builders/UIView/Views/URLOpener.h
+++ b/markymark/Classes/Layout Builders/UIView/Views/URLOpener.h
@@ -1,0 +1,15 @@
+//
+//  URLOpener.h
+//  markymark
+//
+//  Created by Martin Höller on 14.11.18.
+//
+
+#import <Foundation/Foundation.h>
+NS_ASSUME_NONNULL_BEGIN
+
+@interface URLOpener : NSObject
+- (void)openURL:(NSURL *)url;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/markymark/Classes/Layout Builders/UIView/Views/URLOpener.m
+++ b/markymark/Classes/Layout Builders/UIView/Views/URLOpener.m
@@ -1,0 +1,39 @@
+//
+//  URLOpener.m
+//  markymark
+//
+//  Created by Martin Höller on 14.11.18.
+//
+
+#import "URLOpener.h"
+
+BOOL IsRunningAsAnExtension()
+{
+    // Per Apple, an extension will have a top level NSExtension dictionary in the info.plist
+    // https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/SystemExtensionKeys.html
+    
+    static BOOL sIsExtension;
+    static dispatch_once_t sOnceToken;
+    dispatch_once(& sOnceToken, ^{
+        NSDictionary *extensionDictionary = [[NSBundle mainBundle] infoDictionary][@"NSExtension"];
+        sIsExtension = [extensionDictionary isKindOfClass:[NSDictionary class]];
+    });
+    return sIsExtension;
+}
+
+@implementation URLOpener
+    
+- (void)openURL:(NSURL *)url
+    {
+#if TARGET_OS_IPHONE
+        if (IsRunningAsAnExtension()) {
+            return;
+        }
+        
+        Class UIApplicationClass = NSClassFromString(@"UIApplication");
+        id sharedApplication = [UIApplicationClass sharedApplication];
+        [sharedApplication performSelector:@selector(openURL:) withObject:url];
+#endif
+    }
+    
+    @end


### PR DESCRIPTION
Certain APIs like `UIApplication` are not allowed to be used in app extensions and dynamically linked libraries.

This PR fixes #71 by not using `UIApplication` directly in `AttributedInteractiveLabel` to open a URL but "hiding" it in an Objective-C wrapper, using Objective-C's weak typing. Also, `openURL` is not executed if called in an extension.
