### PR TITLE
BugFix for issue #64

### DIFF
--- a/markymark/Classes/Default implementations/MarkDownTextView.swift
+++ b/markymark/Classes/Default implementations/MarkDownTextView.swift
@@ -15,7 +15,7 @@ public enum MarkDownConfiguration {
 @IBDesignable
 public class MarkDownTextView: UIView {
 
-    public var styling: DefaultStyling
+    public private(set) var styling: DefaultStyling
 
     @IBInspectable
     public var text: String? = nil {


### PR DESCRIPTION
Made the styling property styling on MarkDownTextView private(set), so you can override the styling properties but can't replace it with another styling. The convenience MarkDownTextView requires it on init to be able to set all internal configuration.

Considered adding a didSet to the property, but too much has to be reinitialised defeating the purpose of the simple markdown textview way of paring styling.

Issue as assumed:
1. Init MarkDownTextView:
```let markdownTextView = MarkDownTextView()
markdownTextView.text = "Dummy text"
```
2. Setup a new styling with :
```let newStyling = DefaultStyling()
newStyling.codeBlockStyling.contentInsets = UIEdgeInsets(top: 5.0, left: 15.0, bottom: 5.0, right: 15.0)
```

3. Apply new styling with:
```
markdownTextView.styling = newStyling
```
4. Results in text not being rerendered and not having the correct styling.