### PR TITLE
add MinimumHeightStylingRule so Paragraphs containing only an empty l…

### DIFF
--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
@@ -22,7 +22,7 @@ class ParagraphViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuil
         }
 
         let spacing: UIEdgeInsets? = (styling as? ContentInsetStylingRule)?.contentInsets
-        let minimumHeight: CGFloat? = (styling as? MinimumHeightStylingRule)?.minHeight
+        let minimumHeight: CGFloat? = (styling as? MinimumHeightStylingRule)?.minimumHeight
         return ContainerView(view: label, spacing: spacing, minimumHeight: minimumHeight)
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
@@ -22,7 +22,7 @@ class ParagraphViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuil
         }
 
         let spacing: UIEdgeInsets? = (styling as? ContentInsetStylingRule)?.contentInsets
-        let minHeight: CGFloat? = (styling as? MinimumHeightStylingRule)?.minHeight
-        return ContainerView(view: label, spacing: spacing, minHeight:minHeight)
+        let minimumHeight: CGFloat? = (styling as? MinimumHeightStylingRule)?.minHeight
+        return ContainerView(view: label, spacing: spacing, minimumHeight: minimumHeight)
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
@@ -22,6 +22,7 @@ class ParagraphViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuil
         }
 
         let spacing: UIEdgeInsets? = (styling as? ContentInsetStylingRule)?.contentInsets
-        return ContainerView(view: label, spacing: spacing)
+        let minHeight: CGFloat? = (styling as? MinimumHeightStylingRule)?.minHeight
+        return ContainerView(view: label, spacing: spacing, minHeight:minHeight)
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
+++ b/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
@@ -12,7 +12,7 @@ import UIKit
 
 class ContainerView: UIView {
 
-    init(view: UIView, spacing: UIEdgeInsets? = nil, minHeight: CGFloat? = nil) {
+    init(view: UIView, spacing: UIEdgeInsets? = nil, minimumHeight: CGFloat? = nil) {
         super.init(frame: CGRect())
 
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -31,10 +31,10 @@ class ContainerView: UIView {
 
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(left)-[view]-(right)-|", options: [], metrics: metrics, views: views)
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-(top)-[view]-(bottom)-|", options: [], metrics: metrics, views: views)
-        if minHeight != nil {
+        if let minimumHeight = minimumHeight {
             let heightMetrics: [String: CGFloat] = [
-                "height": minHeight!
-                ]
+                "height": minimumHeight
+            ]
             constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:[view(>=height)]", options: [], metrics: heightMetrics, views: views)
         }
         

--- a/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
+++ b/markymark/Classes/Layout Builders/UIView/Views/ContainerView.swift
@@ -12,7 +12,7 @@ import UIKit
 
 class ContainerView: UIView {
 
-    init(view: UIView, spacing: UIEdgeInsets? = nil) {
+    init(view: UIView, spacing: UIEdgeInsets? = nil, minHeight: CGFloat? = nil) {
         super.init(frame: CGRect())
 
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -31,7 +31,13 @@ class ContainerView: UIView {
 
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|-(left)-[view]-(right)-|", options: [], metrics: metrics, views: views)
         constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|-(top)-[view]-(bottom)-|", options: [], metrics: metrics, views: views)
-
+        if minHeight != nil {
+            let heightMetrics: [String: CGFloat] = [
+                "height": minHeight!
+                ]
+            constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:[view(>=height)]", options: [], metrics: heightMetrics, views: views)
+        }
+        
         addConstraints(constraints)
     }
 

--- a/markymark/Classes/Styling/ParagraphStyling.swift
+++ b/markymark/Classes/Styling/ParagraphStyling.swift
@@ -28,7 +28,7 @@ public struct ParagraphStyling: ItemStyling, TextColorStylingRule, LineHeightSty
 
     public var letterSpacing: CGFloat?
 
-    public var minHeight: CGFloat?
+    public var minimumHeight: CGFloat?
     
     public init() {}
 }

--- a/markymark/Classes/Styling/ParagraphStyling.swift
+++ b/markymark/Classes/Styling/ParagraphStyling.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public struct ParagraphStyling: ItemStyling, TextColorStylingRule, LineHeightStylingRule, BaseFontStylingRule, ContentInsetStylingRule, BoldStylingRule, ItalicStylingRule, TextAlignmentStylingRule, LetterSpacingStylingRule {
+public struct ParagraphStyling: ItemStyling, TextColorStylingRule, LineHeightStylingRule, BaseFontStylingRule, ContentInsetStylingRule, BoldStylingRule, ItalicStylingRule, TextAlignmentStylingRule, LetterSpacingStylingRule, MinimumHeightStylingRule {
 
     public var parent: ItemStyling?
 
@@ -28,5 +28,7 @@ public struct ParagraphStyling: ItemStyling, TextColorStylingRule, LineHeightSty
 
     public var letterSpacing: CGFloat?
 
+    public var minHeight: CGFloat?
+    
     public init() {}
 }

--- a/markymark/Classes/Styling/Protocols/MinimumHeightStylingRule.swift
+++ b/markymark/Classes/Styling/Protocols/MinimumHeightStylingRule.swift
@@ -7,5 +7,5 @@ import Foundation
 
 public protocol MinimumHeightStylingRule: ItemStyling {
     
-    var minHeight: CGFloat? { get }
+    var minimumHeight: CGFloat? { get }
 }

--- a/markymark/Classes/Styling/Protocols/MinimumHeightStylingRule.swift
+++ b/markymark/Classes/Styling/Protocols/MinimumHeightStylingRule.swift
@@ -1,0 +1,11 @@
+//
+//  MinimumHeightStylingRule.swift
+//  Created by kris on 19.02.19.
+//
+
+import Foundation
+
+public protocol MinimumHeightStylingRule: ItemStyling {
+    
+    var minHeight: CGFloat? { get }
+}


### PR DESCRIPTION
…ine dont end up with zero height when using MarkdownConfiguration.view

A text paragraph like "Lorem ipsum\n\nDolor sit amet." will be parsed into 3 single paragraphs, of which the middle one will contain an empty line. 
This will be rendered to a zero-height view.
Not an issue per se, but in combination with a ParagraphStyling with no top/bottom contentInsets this will appear as if the new line was simply cut away.

By setting the new fully optional minHeight property, the container for each paragraph will be constrained to show with at least the given height to show even with empty lines.