### PR TITLE
ref #92 - Expose a post configuration closure for UITextViews created…

### DIFF
--- a/markymark/Classes/Default implementations/MarkDownTextView.swift
+++ b/markymark/Classes/Default implementations/MarkDownTextView.swift
@@ -16,7 +16,8 @@ public enum MarkDownConfiguration {
 public class MarkDownTextView: UIView {
 
     public var onDidConvertMarkDownItemToView:((_ markDownItem: MarkDownItem, _ view: UIView) -> Void)?
-
+    public var onDidPreconfigureTextView:((_ textView: UITextView) -> Void)?
+    
     public private(set) var styling: DefaultStyling
 
     @IBInspectable
@@ -171,6 +172,8 @@ private struct MarkDownAsAttributedStringViewConfiguration: CanConfigureViews {
         textView.tintColor = owner.styling.linkStyling.textColor
         textView.translatesAutoresizingMaskIntoConstraints = false
 
+        owner.onDidPreconfigureTextView?(textView)
+        
         owner.markDownView = textView
     }
 


### PR DESCRIPTION
… by MarkDownAsAttributedStringViewConfiguration so that UITextViews can be further customized if needed.

see https://github.com/M2Mobi/Marky-Mark/issues/92