### PR TITLE
Add textViewDelegate to MarkdownTextView

### DIFF
--- a/markymark/Classes/Default implementations/MarkDownTextView.swift
+++ b/markymark/Classes/Default implementations/MarkDownTextView.swift
@@ -34,6 +34,13 @@ open class MarkDownTextView: UIView {
         }
     }
 
+    public var textViewDelegate: UITextViewDelegate? {
+        didSet {
+            (viewConfiguration as? MarkDownAsAttributedStringViewConfiguration)?.textViewDelegate = textViewDelegate
+            render(withMarkdownText: text)
+        }
+    }
+
     fileprivate var markDownView: UIView?
     fileprivate var markDownItems: [MarkDownItem] = []
     private let markyMark: MarkyMark
@@ -146,8 +153,9 @@ private class MarkDownAsViewViewConfiguration: CanConfigureViews {
     }
 }
 
-private struct MarkDownAsAttributedStringViewConfiguration: CanConfigureViews {
+private class MarkDownAsAttributedStringViewConfiguration: CanConfigureViews {
 
+    weak var textViewDelegate: UITextViewDelegate?
     private weak var owner: MarkDownTextView?
 
     init(owner: MarkDownTextView) {
@@ -164,6 +172,7 @@ private struct MarkDownAsAttributedStringViewConfiguration: CanConfigureViews {
         let textView = UITextView()
         textView.isScrollEnabled = false
         textView.isEditable = false
+        textView.delegate = textViewDelegate
 
         textView.attributedText = attributedString
         textView.dataDetectorTypes = [.phoneNumber, .link]


### PR DESCRIPTION
Added text view delegate to markdown text view in order to have ability to write custom url handler https://github.com/M2Mobi/Marky-Mark/issues/99

```
class ExampleViewController: UIViewController {
    override func viewDidLoad() {
        super.viewDidLoad()
        markDownTextView?.text = "random text"
        markDownTextView?.textViewDelegate = self
    }
}

extension ExampleViewController: UITextViewDelegate {
  func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
    // custom url handling logic
    return true
  }
}
```



