### PR TITLE
Add support for <https://m2mobi.com> style links

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - markymark (10.1.1)
+  - markymark (10.1.2)
   - SwiftLint (0.28.1)
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  markymark: 29adb8789fa6b3db97b04b7585d65f13931b5aa5
+  markymark: 98903145fd4c412c9b7836c6a40e427652e8cca2
   SwiftLint: 7f5f7de0da74a649b16616cb5246ae323489656e
 
 PODFILE CHECKSUM: e6179d5e64bda0057471cea1521ff93bf207a88b

--- a/Example/Tests/Rules/Inline/ShortLinkRuleTests.swift
+++ b/Example/Tests/Rules/Inline/ShortLinkRuleTests.swift
@@ -1,0 +1,96 @@
+//
+//  ShortLinkRuleTests.swift
+//  markymark_Tests
+//
+//  Created by Jim van Zummeren on 20/07/2021.
+//  Copyright © 2021 M2mobi. All rights reserved.
+//
+
+import XCTest
+@testable import markymark
+
+class ShortLinkRuleTests: XCTestCase {
+
+    var sut: ShortLinkRule!
+
+    override func setUp() {
+        super.setUp()
+        sut = ShortLinkRule()
+    }
+
+    func test_WillRecognizesLines_When_CallingRecognizesLinesWithValidInput() {
+        XCTAssertTrue(sut.recognizesLines(["<https://www.m2mobi.com>"]))
+        XCTAssertTrue(sut.recognizesLines(["<http://www.m2mobi.nl/something/other?id=4&page=4>"]))
+        XCTAssertTrue(sut.recognizesLines(["<hkia://flights>"]))
+        XCTAssertTrue(sut.recognizesLines(["<google.com>"]))
+    }
+
+    func test_WillNotRecognizesLines_When_CallingRecognizesLinesWithInvalidInput() {
+        XCTAssertFalse(sut.recognizesLines(["<Google>"]))
+        XCTAssertFalse(sut.recognizesLines(["<$$>"]))
+        XCTAssertFalse(sut.recognizesLines(["<hello>"]))
+        XCTAssertFalse(sut.recognizesLines(["<hello .com>"]))
+    }
+
+    func test_GetAllMatchesReturnsZero_When_CallinGetAllMatchesWithInvalidInput() {
+        // Assert
+        XCTAssert(sut.getAllMatches(["(https://www.google.com)"]).isEmpty)
+        XCTAssert(sut.getAllMatches(["<Google>"]).isEmpty)
+        XCTAssert(sut.getAllMatches(["<M2mobi .com>"]).isEmpty)
+    }
+
+    func test_WillReturnCorrectRanges_WhenCallingGetAllMatchesWithValidInput() {
+        // Arrange
+        let expectedMatchesRange = NSRange(location: 0, length: 23)
+        let expectedMatchesRange2 = NSRange(location: 29, length: 27)
+
+        // Act + Assert
+        XCTAssertEqual(sut.getAllMatches(["<http://www.m2mobi.com>"]), [expectedMatchesRange])
+        XCTAssertEqual(
+            sut.getAllMatches(["<http://www.m2mobi.com> test <http://www.contentful.com>"]),
+            [expectedMatchesRange, expectedMatchesRange2]
+        )
+    }
+
+    func test_WillCreateLinkMarkDownItem_When_CallingCreateWithValidInput() {
+        // Act
+        let markDownItem = sut.createMarkDownItemWithLines(["<http://www.google.com>"])
+
+        // Assert
+        XCTAssert(markDownItem is LinkMarkDownItem)
+    }
+
+    func test_ParsesItem_When_InputMatches() throws {
+        // Arrange
+        let cases: [(String, String, String, UInt)] = [
+            (
+                "<https://google.com>",
+                "https://google.com",
+                "https://google.com",
+                #line
+            ),
+            (
+                "Inside <http://m2mobi.com> sentence",
+                "http://m2mobi.com",
+                "http://m2mobi.com",
+                #line
+            ),
+            (
+                "Multiple <http://m2mobi.com> in one sentence <http://contentful.com>",
+                "http://m2mobi.com",
+                "http://m2mobi.com",
+                #line
+            )
+        ]
+
+        for (input, content, url, line) in cases {
+            // Act
+            let output = sut.createMarkDownItemWithLines([input])
+
+            // Assert
+            let linkMarkDownItem = try XCTUnwrap(output as? LinkMarkDownItem)
+            XCTAssertEqual(linkMarkDownItem.content, content, line: line)
+            XCTAssertEqual(linkMarkDownItem.url, url, line: line)
+        }
+    }
+}

--- a/Example/Tests/Rules/Inline/ShortLinkRuleTests.swift
+++ b/Example/Tests/Rules/Inline/ShortLinkRuleTests.swift
@@ -27,6 +27,7 @@ class ShortLinkRuleTests: XCTestCase {
 
     func test_WillNotRecognizesLines_When_CallingRecognizesLinesWithInvalidInput() {
         XCTAssertFalse(sut.recognizesLines(["<Google>"]))
+        XCTAssertFalse(sut.recognizesLines(["<>"]))
         XCTAssertFalse(sut.recognizesLines(["<$$>"]))
         XCTAssertFalse(sut.recognizesLines(["<hello>"]))
         XCTAssertFalse(sut.recognizesLines(["<hello .com>"]))

--- a/Example/markymark.xcodeproj/project.pbxproj
+++ b/Example/markymark.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		018E014626A6AC4000B6A4A3 /* ShortLinkRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 018E014526A6AC4000B6A4A3 /* ShortLinkRuleTests.swift */; };
 		07614EA220B5565F00917A0C /* AdvancedMarkdownViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07614EA120B5565F00917A0C /* AdvancedMarkdownViewController.swift */; };
 		07EC79F51CF3A19D004239CB /* ListRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EC79F41CF3A19D004239CB /* ListRuleTests.swift */; };
 		1E5D871F2AD8705B0A87B17C /* Pods_markymark_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E8357CFD26059D0E00EA777 /* Pods_markymark_Example.framework */; };
@@ -82,6 +83,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		018E014526A6AC4000B6A4A3 /* ShortLinkRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortLinkRuleTests.swift; sourceTree = "<group>"; };
 		07614EA120B5565F00917A0C /* AdvancedMarkdownViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedMarkdownViewController.swift; sourceTree = "<group>"; };
 		07EC79F41CF3A19D004239CB /* ListRuleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListRuleTests.swift; sourceTree = "<group>"; };
 		09F6D551E99F224FBB0ACEA1 /* Pods-markymark_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-markymark_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-markymark_Example/Pods-markymark_Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 				9A8BE0A71CEE0416004593A0 /* ItalicRuleTests.swift */,
 				9A8BE0A81CEE0416004593A0 /* LinkRuleTests.swift */,
 				9A8BE0A91CEE0416004593A0 /* StrikeRuleTests.swift */,
+				018E014526A6AC4000B6A4A3 /* ShortLinkRuleTests.swift */,
 			);
 			path = Inline;
 			sourceTree = "<group>";
@@ -646,6 +649,7 @@
 				9A957FAF1CF730FB00465146 /* OrderedListTypeTests.swift in Sources */,
 				629C424D1CEB4B3000DA57D8 /* MarkyMarkTests.swift in Sources */,
 				629C42441CEB4B3000DA57D8 /* ParagraphRuleTests.swift in Sources */,
+				018E014626A6AC4000B6A4A3 /* ShortLinkRuleTests.swift in Sources */,
 				629C424C1CEB4B3000DA57D8 /* MarkDownLinesTests.swift in Sources */,
 				629C42451CEB4B3000DA57D8 /* MarkDownConverterConfigurationTests.swift in Sources */,
 				629C42421CEB4B3000DA57D8 /* MarkyMarkContentfulIntegrationTests.swift in Sources */,

--- a/Example/markymark/markdown.txt
+++ b/Example/markymark/markdown.txt
@@ -1,5 +1,5 @@
 # Paragraphs
-Lorem ipsum *dolor* sit amet, __consectetur__ adipiscing elit. Proin ***aliquet vulputate*** diam. Emoji 🤘. Duis sodales ~~sapien~~ quis ***elementum* posuere**. Duis quam lectus, posueresed  [~~pellentesqueaauctor~~](https://m2mobi.com) eu [Velit](https://m2mobi.com).
+Lorem ipsum *dolor* sit amet, __consectetur__ adipiscing elit. Proin ***aliquet vulputate*** diam. Emoji 🤘. Duis sodales ~~sapien~~ quis ***elementum* posuere**. Duis quam lectus, posueresed  [~~pellentesqueaauctor~~](https://m2mobi.com) eu [Velit](https://m2mobi.com). Also <https://www.m2mobi.com> and <https://www.google.com> but not <Google>.
 
 # Headers
 ---

--- a/markymark/Classes/Default implementations/Attributed label/AttributedLabelFlavor.swift
+++ b/markymark/Classes/Default implementations/Attributed label/AttributedLabelFlavor.swift
@@ -16,7 +16,8 @@ open class AttributedLabelFlavor: Flavor {
         ItalicRule(),
         BoldRule(),
         StrikeRule(),
-        LinkRule()
+        LinkRule(),
+        ShortLinkRule()
     ]
 
     open var defaultInlineRule: InlineRule = InlineTextRule()

--- a/markymark/Classes/Flavors/ContentfulFlavor.swift
+++ b/markymark/Classes/Flavors/ContentfulFlavor.swift
@@ -23,6 +23,7 @@ open class ContentfulFlavor: Flavor {
 
     open var inlineRules: [InlineRule] = [
         LinkRule(),
+        ShortLinkRule(),
         BoldRule(),
         ItalicRule(),
         StrikeRule(),

--- a/markymark/Classes/Rules/Inline/ShortLinkRule.swift
+++ b/markymark/Classes/Rules/Inline/ShortLinkRule.swift
@@ -1,0 +1,63 @@
+//
+//  ShortLinkRule.swift
+//  markymark
+//
+//  Created by Jim van Zummeren on 20/07/2021.
+//  Copyright © 2021 M2mobi. All rights reserved.
+//
+
+import Foundation
+
+open class ShortLinkRule: InlineRule {
+    
+    /// Example: <http://www.google.com>
+    open var expression = NSRegularExpression.expressionWithPattern(
+        #"<(.+?)>"#
+    )
+        
+    public func getAllMatches(_ lines: [String]) -> [NSRange] {
+        guard let line = lines.first else { return [] }
+        return getResults(line).map { $0.range }
+    }
+
+    // MARK: Rule
+
+    public func recognizesLines(_ lines: [String]) -> Bool {
+        guard let line = lines.first else { return false }
+        return getResults(line).count > 0
+    }
+
+    public func createMarkDownItemWithLines(_ lines: [String]) -> MarkDownItem {
+        let url: String? = lines.first?.subStringWithExpression(expression, ofGroup: 1)
+
+        return LinkMarkDownItem(
+            lines: lines,
+            content: url ?? "",
+            url: url ?? ""
+        )
+    }
+}
+
+private extension ShortLinkRule {
+
+    private func getResults(_ string: String) -> [NSTextCheckingResult] {
+        let range = NSRange(location: 0, length: string.length())
+        let results = expression.matches(in: string, options: [], range: range)
+        
+        let validResults = results.filter {
+            isValidURLString(string.subString($0.range(at: 1)))
+        }
+        
+        return validResults
+    }
+    
+    private func isValidURLString(_ string: String) -> Bool {
+        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+        if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count)) {
+            // it is a link, if the match covers the whole string
+            return match.range.length == string.utf16.count
+        } else {
+            return false
+        }
+    }
+}

--- a/markymark/Classes/Rules/Inline/ShortLinkRule.swift
+++ b/markymark/Classes/Rules/Inline/ShortLinkRule.swift
@@ -40,7 +40,7 @@ open class ShortLinkRule: InlineRule {
 
 private extension ShortLinkRule {
 
-    private func getResults(_ string: String) -> [NSTextCheckingResult] {
+    func getResults(_ string: String) -> [NSTextCheckingResult] {
         let range = NSRange(location: 0, length: string.length())
         let results = expression.matches(in: string, options: [], range: range)
         
@@ -50,8 +50,8 @@ private extension ShortLinkRule {
         
         return validResults
     }
-    
-    private func isValidURLString(_ string: String) -> Bool {
+
+     func isValidURLString(_ string: String) -> Bool {
         let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
         if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count)) {
             // it is a link, if the match covers the whole string

--- a/markymark/Classes/Rules/Inline/ShortLinkRule.swift
+++ b/markymark/Classes/Rules/Inline/ShortLinkRule.swift
@@ -52,12 +52,17 @@ private extension ShortLinkRule {
     }
 
      func isValidURLString(_ string: String) -> Bool {
-        let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-        if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count)) {
-            // it is a link, if the match covers the whole string
-            return match.range.length == string.utf16.count
-        } else {
-            return false
-        }
+         do {
+            let detector = try NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
+            if let match = detector.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count)) {
+                // it is a link, if the match covers the whole string
+                return match.range.length == string.utf16.count
+            } else {
+                return false
+            }
+         } catch {
+             return false
+         }
     }
 }

--- a/markymark/Classes/Rules/Inline/ShortLinkRule.swift
+++ b/markymark/Classes/Rules/Inline/ShortLinkRule.swift
@@ -15,19 +15,19 @@ open class ShortLinkRule: InlineRule {
         #"<(.+?)>"#
     )
         
-    public func getAllMatches(_ lines: [String]) -> [NSRange] {
+    open func getAllMatches(_ lines: [String]) -> [NSRange] {
         guard let line = lines.first else { return [] }
         return getResults(line).map { $0.range }
     }
 
     // MARK: Rule
 
-    public func recognizesLines(_ lines: [String]) -> Bool {
+    open func recognizesLines(_ lines: [String]) -> Bool {
         guard let line = lines.first else { return false }
         return getResults(line).count > 0
     }
 
-    public func createMarkDownItemWithLines(_ lines: [String]) -> MarkDownItem {
+    open func createMarkDownItemWithLines(_ lines: [String]) -> MarkDownItem {
         let url: String? = lines.first?.subStringWithExpression(expression, ofGroup: 1)
 
         return LinkMarkDownItem(


### PR DESCRIPTION
As filed by SMiller at https://github.com/M2mobi/Marky-Mark/issues/110.

This Pull request addd support for <https://m2mobi.com> style links