### PR TITLE
Fixes links that contain special characters in the aria-label

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - markymark (10.1.1)
+  - markymark (10.1.2)
   - SwiftLint (0.28.1)
 
 DEPENDENCIES:
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - SwiftLint
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  trunk:
     - SwiftLint
 
 EXTERNAL SOURCES:
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  markymark: 29adb8789fa6b3db97b04b7585d65f13931b5aa5
+  markymark: 98903145fd4c412c9b7836c6a40e427652e8cca2
   SwiftLint: 7f5f7de0da74a649b16616cb5246ae323489656e
 
 PODFILE CHECKSUM: e6179d5e64bda0057471cea1521ff93bf207a88b
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/Example/Tests/Rules/Inline/LinkRuleTests.swift
+++ b/Example/Tests/Rules/Inline/LinkRuleTests.swift
@@ -19,6 +19,7 @@ class LinkRuleTests: XCTestCase {
         XCTAssertTrue(sut.recognizesLines(["[Alt text](image.png)"]))
         XCTAssertFalse((sut.recognizesLines(["![Alt text](image.png)"])))
         XCTAssertTrue(sut.recognizesLines([#"[Alt text](image.png "some title")"#]))
+        XCTAssertTrue(sut.recognizesLines([#"[Alt text](https://www.website.com/ "some-test")"#]))
     }
 
     func test_DoesNotRecognizeLines_When_PrefixedWithExclamationMark() {
@@ -46,6 +47,18 @@ class LinkRuleTests: XCTestCase {
         // Act
         let markDownItem = sut.createMarkDownItemWithLines(["[Google](http://www.google.com)"])
         let markDownItem2 = sut.createMarkDownItemWithLines(["[Youtube](http://www.youtube.com)"])
+
+        // Assert
+        XCTAssertEqual((markDownItem as! LinkMarkDownItem).content, "Google")
+        XCTAssertEqual((markDownItem as! LinkMarkDownItem).url, "http://www.google.com")
+        XCTAssertEqual((markDownItem2 as! LinkMarkDownItem).content, "Youtube")
+        XCTAssertEqual((markDownItem2 as! LinkMarkDownItem).url, "http://www.youtube.com")
+    }
+
+    func testCreateMarkDownItemContainsCorrectLinkWhenUsingAriaLabel() {
+        // Act
+        let markDownItem = sut.createMarkDownItemWithLines([#"[Google](http://www.google.com "Google")"#])
+        let markDownItem2 = sut.createMarkDownItemWithLines([#"[Youtube](http://www.youtube.com "You-tube")"#])
 
         // Assert
         XCTAssertEqual((markDownItem as! LinkMarkDownItem).content, "Google")

--- a/Example/markymark.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/markymark.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/markymark.podspec
+++ b/markymark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "markymark"
-  s.version          = "10.1.2"
+  s.version          = "10.1.3"
   s.summary          = "Markdown parser for iOS"
   s.description      = <<-DESC
 Marky Mark is a parser written in Swift that converts markdown into native views. The way it looks is highly customizable and the supported markdown syntax and tags are easy to extend.

--- a/markymark/Classes/Rules/Inline/LinkRule.swift
+++ b/markymark/Classes/Rules/Inline/LinkRule.swift
@@ -12,7 +12,7 @@ open class LinkRule: InlineRegexRule {
     /// Example: [Google](http://www.google.com "with custom title")
     open var expression = NSRegularExpression.expressionWithPattern(
         //             [  title  ] (    URL   "     optional title    "   )
-        #"(?<!!\p{Z}?)\[{1}(.+?)\]\({1}(.+?)( "[[:alnum:][:space:]^"]+")?\)"#
+        #"(?<!!\p{Z}?)\[{1}(.+?)\]\({1}(.+?)( "[[:print:][:space:]^"]+")?\)"#
     )
 
     // MARK: Rule

--- a/markymark/Classes/Rules/Inline/LinkRule.swift
+++ b/markymark/Classes/Rules/Inline/LinkRule.swift
@@ -12,7 +12,7 @@ open class LinkRule: InlineRegexRule {
     /// Example: [Google](http://www.google.com "with custom title")
     open var expression = NSRegularExpression.expressionWithPattern(
         //             [  title  ] (    URL   "     optional title    "   )
-        #"(?<!!\p{Z}?)\[{1}(.+?)\]\({1}(.+?)( "[[:print:][:space:]^"]+")?\)"#
+        #"(?<!!\p{Z}?)\[{1}(.+?)\]\({1}(.+?)( "[[:print:]^"]+")?\)"#
     )
 
     // MARK: Rule


### PR DESCRIPTION
This improvement fixes links such as `[Alt text](https://www.website.com/ "some-test")`, which has a special character in the aria-label "Some-test"

More information about the regex change:
https://www.gnu.org/software/grep/manual/html_node/Character-Classes-and-Bracket-Expressions.html

‘[:print:]’
Printable characters: ‘[:alnum:]’, ‘[:punct:]’, and space.


‘[:alnum:]’
Alphanumeric characters: ‘[:alpha:]’ and ‘[:digit:]’; in the ‘C’ locale and ASCII character encoding, this is the same as ‘[0-9A-Za-z]’.