### PR TITLE
Add inline rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,21 @@ https://github.com/M2Mobi/Marky-Mark
 ## Simple usage
 
 ### View with default styling
+
 ```swift
 let markDownView = MarkDownTextView()
 markDownView.text = "# Header\nParagraph"
+```
+
+MarkDownTextView can be used with two configurations, either `view` or `attributedString`. In both cases the paragraphs will be rendered as `attributedString`, but when using the `view` configuration each 'block' (each new line in the markdown text is considered a block) will be rendered as view. The `view` option is recommended for better layout and flexibility but offers slightly less performance than the `attributedString` option. The default configuration is `view`.
+
+
+```swift
+let markDownView = MarkDownTextView(markDownConfiguration: .view)
+```
+
+```swift
+let markDownView = MarkDownTextView(markDownConfiguration: .attributedString)
 ```
 
 ### View with modified styling
@@ -54,8 +66,8 @@ markDownView.styling.paragraphStyling.baseFont = .systemFont(ofSize: 14)
 markDownView.text = "# Header\nParagraph"
 ```
 
-
 ## Supported tags in the Default Flavor
+
 Note: Different tags can be supported by either extending the ContentfulFlavor (default) or by implementing a class that comforms to `Flavor` and implement the required `Rule`'s
 
 ```
@@ -97,7 +109,6 @@ Code
 \```code```
 ```
 
-
 ### Customizing default style
 
 Default Styling instance
@@ -105,7 +116,9 @@ Default Styling instance
 ```swift
 var styling = DefaultStyling()
 ```
+
 #### Paragraphs (regular text)
+
 Markdown example: `Some text`
 
 ```swift
@@ -147,6 +160,7 @@ styling.headingStyling.textAlignment = .left
 ```
 
 #### linkStyling
+
 Markdown Example `[Google](http://www.google.com)`
 
 ```swift
@@ -159,6 +173,7 @@ styling.linkStyling.isUnderlined = true
 ```
 
 #### List styling
+
 Markdown Example:
 
 ```
@@ -214,6 +229,7 @@ _Please check the `DefaultStyling` class for more information_
 
 
 ## Advanced usage
+
 Advanced usage is only needed for very specific cases. Making subsets of styling, making different styling combinations, supporting different Markdown rules (syntax) or modifying certain views after that have been generated.
 
 ### Custom styling objects
@@ -250,38 +266,43 @@ MarkDownTextView(styling: CustomMarkyMarkStyling())
 ```
 
 ### Adding your own rules
+
 Adding a new rule requires three new classes of based on the following protocol:
 
-* `Rule` that can recoginizes the desired markdown syntax
+* `Rule` or `InlineRule` that can recoginizes the desired markdown syntax
 * `MarkDownItem` for your new element that will be created by your new rule
 * `LayoutBlockBuilder` that can convert your MarkDownItem to layout
 
-Add the rule to MarkyMark
-
-```swift
-markyMark.addRule(MyCustomRule())
-```
-
-Or when using the MarkdownTextView:
+To add a 'block' rule such as a Paragraph, List or Code Block:
 
 ```swift
 markdownTextView.add(rule: MyCustomRule())
 ```
 
-Add the block builder to your layout converter
+To add an 'inline' rule such as a Bold, Italic, Link:
 
 ```swift
-converter.addLayoutBlockBuilder(MyCustomLayoutBlockBuilder())
+markdownTextView.add(inlineRule: MyCustomInlineRule())
 ```
 
-Or when using the MarkdownTextView use either of these options (depending on the configuration view or attributedString):
+Use either options to add a layout builder for a 'block' MarkDownItem created by a 'block' `Rule` (depending on the configuration view or attributedString):
+
+For view: 
 
 ```swift
 markdownTextView.addViewLayoutBlockBuilder(MyCustomLayoutBlockBuilder())
 ```
 
+For attributedString:
+
 ```swift
 markdownTextView.addAttributedStringLayoutBlockBuilder(MyCustomLayoutBlockBuilder())
+```
+
+To add a layout builder for an inline item (MarkdownItem to attributedString) created be a `InlineRule`:
+
+```swift
+markdownTextView.addInlineLayoutBlockBuilder(MyCustomInlineLayoutBlockBuilder())
 ```
 
 If needed you can also add a custom styling class to the default styling
@@ -291,16 +312,9 @@ styling.addStyling(MyCustomStyling())
 ```
 
 ### Converter hook
-The converter has a callback method which is called every time a `MarkDownItem` is converted to layout. 
+The converter has a callback method which is called every time a `MarkDownItem` is converted to view.
 
-```swift
-converter.didConvertElement = {
-	markDownItem, view in
-	// Do something with markDownItem and / or view here
-}
-```
-
-When using the MarkdownTextView
+For view configuration: 
 
 ```swift
 markDownTextView.onDidConvertMarkDownItemToView = {
@@ -309,8 +323,19 @@ markDownTextView.onDidConvertMarkDownItemToView = {
 }
 ```
 
+or when using attributedString configuration:
+
+```swift
+markDownTextView.onDidConvertMarkDownItemToAttributedString = {
+    markDownItem, string in
+
+}
+```
+
 ### Link behavior
 By default Markymark opens URL's using `UIApplication.shared.delegate.open(_:open:options)`. links will only be openened when this method is implemented. Markymark allows changing this behavior by passing a custom URLOpener, an object that conforms to the `URLOpener` protocol.
+
+URLOpener can only be used with `view` configuration.
 
 ```swift
 let markDownView = MarkDownTextView()

--- a/markymark/Classes/Default implementations/MarkdownAttributedStringTextView.swift
+++ b/markymark/Classes/Default implementations/MarkdownAttributedStringTextView.swift
@@ -1,0 +1,141 @@
+//
+//  MarkdownAttributedStringTextView.swift
+//  Pods
+//
+//  Created by Jim van Zummeren on 20/03/2022.
+//
+
+import Foundation
+
+open class MarkdownAttributedStringTextView: UIView, MarkDownView {
+
+    public var onDidPreconfigureTextView:((_ textView: UITextView) -> Void)?
+
+    public var onDidConvertMarkDownItemToAttributedString:((_ markDownItem: MarkDownItem, _ view: NSMutableAttributedString) -> ())?
+
+    public var styling: DefaultStyling
+
+    public var text: String? = nil {
+        didSet {
+            render(withMarkdownText: text)
+        }
+    }
+
+    private var markDownView: UITextView?
+    private var markDownItems: [MarkDownItem] = []
+    private let markyMark: MarkyMark
+
+    private let configuration: MarkDownToAttributedStringConverterConfiguration
+    private let converter: MarkDownConverter<NSMutableAttributedString>
+
+    public init(
+        flavor: Flavor = ContentfulFlavor(),
+        styling: DefaultStyling = .init()
+    ) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(flavor)
+        })
+
+        self.styling = styling
+        configuration = .init(styling: styling)
+        converter = .init(configuration: configuration)
+
+        super.init(frame: CGRect())
+    }
+
+    public override init(frame: CGRect) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(ContentfulFlavor())
+        })
+
+        styling = DefaultStyling()
+
+        configuration = .init(styling: styling)
+        converter = .init(configuration: configuration)
+        super.init(frame: frame)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(ContentfulFlavor())
+        })
+
+        styling = DefaultStyling()
+
+        configuration = .init(styling: styling)
+        converter = .init(configuration: configuration)
+        super.init(coder: aDecoder)
+    }
+
+    public func add(rule: Rule) {
+        markyMark.addRule(rule)
+    }
+
+    public func add(inlineRule: InlineRule) {
+        markyMark.addInlineRule(inlineRule)
+    }
+
+    public func addViewLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString>) {
+        configuration.addLayoutBlockBuilder(layoutBlockBuilder)
+    }
+
+    public func addInlineLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString>) {
+        configuration.addInlineLayoutBlockBuilder(layoutBlockBuilder)
+    }
+}
+
+private extension MarkdownAttributedStringTextView {
+
+    private func render(withMarkdownText markdownText: String?) {
+        markDownView?.removeFromSuperview()
+
+        guard let markdownText = markdownText else {
+            markDownItems = []
+            return
+        }
+
+        markDownItems = markyMark.parseMarkDown(markdownText)
+        configureViews()
+    }
+}
+
+extension MarkdownAttributedStringTextView: CanConfigureViews {
+
+    func configureViewProperties() {
+        let attributedString = converter.convert(markDownItems)
+
+        let textView = UITextView()
+
+        textView.isScrollEnabled = false
+        textView.isEditable = false
+
+        textView.attributedText = attributedString
+        textView.dataDetectorTypes = [.phoneNumber, .link]
+        textView.attributedText = attributedString
+
+        textView.tintColor = styling.linkStyling.textColor
+        textView.translatesAutoresizingMaskIntoConstraints = false
+
+        onDidPreconfigureTextView?(textView)
+
+        markDownView = textView
+    }
+
+    func configureViewHierarchy() {
+        guard let markDownView = markDownView else { return }
+        addSubview(markDownView)
+    }
+
+    func configureViewLayout() {
+        guard let markDownView = markDownView else { return }
+
+        let views: [String: Any] = [
+            "markDownView": markDownView
+        ]
+
+        var constraints: [NSLayoutConstraint] = []
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|[markDownView]|", options: [], metrics: [:], views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|[markDownView]|", options: [], metrics: [:], views: views)
+        addConstraints(constraints)
+    }
+}

--- a/markymark/Classes/Default implementations/MarkdownViewTextView.swift
+++ b/markymark/Classes/Default implementations/MarkdownViewTextView.swift
@@ -1,0 +1,136 @@
+//
+//  MarkDownTextView.swift
+//  markymark
+//
+//  Created by Jim van Zummeren on 15/05/2018.
+//
+
+import Foundation
+
+open class MarkdownViewTextView: UIView, MarkDownView {
+
+    public var onDidConvertMarkDownItemToView:((_ markDownItem: MarkDownItem, _ view: UIView) -> ())?
+
+    public var styling: DefaultStyling
+
+    public var text: String? = nil {
+        didSet {
+            render(withMarkdownText: text)
+        }
+    }
+
+    public var urlOpener: URLOpener? {
+        didSet {
+            configuration.urlOpener = urlOpener
+            render(withMarkdownText: text)
+        }
+    }
+
+    private var markDownView: UIView?
+    private var markDownItems: [MarkDownItem] = []
+    private let markyMark: MarkyMark
+
+    private let configuration: MarkdownToViewConverterConfiguration
+    private let converter: MarkDownConverter<UIView>
+
+    public init(
+        flavor: Flavor = ContentfulFlavor(),
+        styling: DefaultStyling = .init()
+    ) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(flavor)
+        })
+
+        self.styling = styling
+        configuration = .init(styling: styling, urlOpener: urlOpener)
+        converter = .init(configuration: configuration)
+
+        super.init(frame: CGRect())
+    }
+
+    public override init(frame: CGRect) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(ContentfulFlavor())
+        })
+
+        styling = DefaultStyling()
+
+        configuration = .init(styling: styling, urlOpener: urlOpener)
+        converter = .init(configuration: configuration)
+        super.init(frame: frame)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        markyMark = MarkyMark(build: {
+            $0.setFlavor(ContentfulFlavor())
+        })
+
+        styling = DefaultStyling()
+
+        configuration = .init(styling: styling, urlOpener: urlOpener)
+        converter = .init(configuration: configuration)
+        super.init(coder: aDecoder)
+    }
+
+    public func add(rule: Rule) {
+        markyMark.addRule(rule)
+    }
+
+    public func add(inlineRule: InlineRule) {
+        markyMark.addInlineRule(inlineRule)
+    }
+
+    public func addViewLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<UIView>) {
+        configuration.addLayoutBlockBuilder(layoutBlockBuilder)
+    }
+
+    public func addInlineLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString>) {
+        configuration.addInlineLayoutBlockBuilder(layoutBlockBuilder)
+    }
+}
+
+private extension MarkdownViewTextView {
+
+    private func render(withMarkdownText markdownText: String?) {
+        markDownView?.removeFromSuperview()
+
+        guard let markdownText = markdownText else {
+            markDownItems = []
+            return
+        }
+
+        markDownItems = markyMark.parseMarkDown(markdownText)
+        configureViews()
+    }
+}
+
+extension MarkdownViewTextView: CanConfigureViews {
+
+    func configureViewProperties() {
+        converter.didConvertElement = {
+            [weak self] markDownItem, view in
+            self?.onDidConvertMarkDownItemToView?(markDownItem, view)
+        }
+
+        markDownView = converter.convert(markDownItems)
+        markDownView?.isUserInteractionEnabled = true
+    }
+
+    func configureViewHierarchy() {
+        guard let markDownView = markDownView else { return }
+        addSubview(markDownView)
+    }
+
+    func configureViewLayout() {
+        guard let markDownView = markDownView else { return }
+
+        let views: [String: Any] = [
+            "markDownView": markDownView
+        ]
+
+        var constraints: [NSLayoutConstraint] = []
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: "H:|[markDownView]|", options: [], metrics: [:], views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: "V:|[markDownView]|", options: [], metrics: [:], views: views)
+        addConstraints(constraints)
+    }
+}

--- a/markymark/Classes/Layout Builders/AttributedString/Block Builders/ContainerAttributedStringBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/AttributedString/Block Builders/ContainerAttributedStringBlockBuilder.swift
@@ -5,11 +5,11 @@
 
 import UIKit
 
-class ContainerAttributedStringBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString> {
+open class ContainerAttributedStringBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString> {
 
     // MARK: LayoutBlockBuilder
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<NSMutableAttributedString>, styling: ItemStyling?) -> NSMutableAttributedString {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<NSMutableAttributedString>, styling: ItemStyling?) -> NSMutableAttributedString {
         let string = NSMutableAttributedString()
 
         if let markDownItems = markDownItem.markDownItems {

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/AlphabeticListLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/AlphabeticListLayoutBlockBuilder.swift
@@ -5,10 +5,10 @@
 
 import Foundation
 
-class AlphabeticListViewLayoutBlockBuilder: ListViewLayoutBlockBuilder {
+open class AlphabeticListViewLayoutBlockBuilder: ListViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return AlphabeticallyOrderedMarkDownItem.self
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/CodeViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/CodeViewLayoutBlockBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class CodeViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
+open class CodeViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return CodeBlockMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let codeBlockMarkDownItem = markDownItem as! CodeBlockMarkDownItem
 
         let label = AttributedInteractiveLabel()

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/HeaderViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/HeaderViewLayoutBlockBuilder.swift
@@ -5,15 +5,15 @@
 
 import UIKit
 
-class HeaderViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
+open class HeaderViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return HeaderMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let headerMarkDownItem = markDownItem as! HeaderMarkDownItem
         let headerStyling = styling as? HeadingStyling
         headerStyling?.configureForLevel(headerMarkDownItem.level)

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/HorizontalLineLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/HorizontalLineLayoutBlockBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class HorizontalLineLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
+open class HorizontalLineLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return HorizontalLineMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
 
         let lineView = LineView()
         lineView.backgroundColor = (styling as? BackgroundStylingRule)?.backgroundColor

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ImageViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ImageViewLayoutBlockBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class ImageViewLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
+open class ImageViewLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return ImageBlockMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let imageBlockMarkDownItem = markDownItem as! ImageBlockMarkDownItem
 
         let imageView = RemoteImageView(file: imageBlockMarkDownItem.file, altText: imageBlockMarkDownItem.altText)

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ListViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ListViewLayoutBlockBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class ListViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
+open class ListViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return UnorderedListMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let listMarkDownItem = markDownItem as! ListMarkDownItem
 
         let listView = getListView(listMarkDownItem, styling: styling)

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/OrderedListLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/OrderedListLayoutBlockBuilder.swift
@@ -5,10 +5,11 @@
 
 import Foundation
 
-class OrderedListViewLayoutBlockBuilder: ListViewLayoutBlockBuilder {
+open class OrderedListViewLayoutBlockBuilder: ListViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return OrderedListMarkDownItem.self
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ParagraphViewLayoutBlockBuilder.swift
@@ -5,15 +5,15 @@
 
 import UIKit
 
-class ParagraphViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
+open class ParagraphViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return ParagraphMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let label = AttributedInteractiveLabel()
         label.markDownAttributedString = attributedStringForMarkDownItem(markDownItem, styling: styling)
 

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/QuoteBlockLayoutBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/QuoteBlockLayoutBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class QuoteBlockLayoutBuilder: InlineAttributedStringViewLayoutBlockBuilder {
+open class QuoteBlockLayoutBuilder: InlineAttributedStringViewLayoutBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return QuoteMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<UIView>, styling: ItemStyling) -> UIView {
         let label = AttributedInteractiveLabel()
         label.markDownAttributedString = attributedStringForMarkDownItem(markDownItem, styling: styling)
 

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Inline/InlineAttributedStringViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Inline/InlineAttributedStringViewLayoutBlockBuilder.swift
@@ -5,18 +5,18 @@
 
 import UIKit
 
-class InlineAttributedStringViewLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
+open class InlineAttributedStringViewLayoutBlockBuilder: LayoutBlockBuilder<UIView>, CanSetURLOpener {
 
     private(set) var urlOpener: URLOpener?
 
     private let converter: MarkDownConverter<NSMutableAttributedString>
 
-    required init(converter: MarkDownConverter<NSMutableAttributedString>) {
+    required public init(converter: MarkDownConverter<NSMutableAttributedString>) {
         self.converter = converter
         super.init()
     }
 
-    func attributedStringForMarkDownItem(_ markdownItem: MarkDownItem, styling: ItemStyling) -> NSMutableAttributedString {
+    open func attributedStringForMarkDownItem(_ markdownItem: MarkDownItem, styling: ItemStyling) -> NSMutableAttributedString {
         let string = NSMutableAttributedString()
 
         if let markDownItems = markdownItem.markDownItems {
@@ -27,11 +27,8 @@ class InlineAttributedStringViewLayoutBlockBuilder: LayoutBlockBuilder<UIView> {
 
         return string
     }
-}
 
-extension InlineAttributedStringViewLayoutBlockBuilder: CanSetURLOpener {
-
-    func set(urlOpener: URLOpener?) {
+    open func set(urlOpener: URLOpener?) {
         self.urlOpener = urlOpener
     }
 }

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Inline/LinkLayoutBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Inline/LinkLayoutBuilder.swift
@@ -6,15 +6,15 @@
 import Foundation
 import UIKit
 
-class LinkViewLayoutBlockBuilder: ContainerAttributedStringBlockBuilder {
+open class LinkViewLayoutBlockBuilder: ContainerAttributedStringBlockBuilder {
 
     // MARK: LayoutBuilder
 
-    override func relatedMarkDownItemType() -> MarkDownItem.Type {
+    override open func relatedMarkDownItemType() -> MarkDownItem.Type {
         return LinkMarkDownItem.self
     }
 
-    override func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<NSMutableAttributedString>, styling: ItemStyling?) -> NSMutableAttributedString {
+    override open func build(_ markDownItem: MarkDownItem, asPartOfConverter converter: MarkDownConverter<NSMutableAttributedString>, styling: ItemStyling?) -> NSMutableAttributedString {
         let linkMarkDownItem = markDownItem as! LinkMarkDownItem
 
         let attributedString = super.build(markDownItem, asPartOfConverter: converter, styling: styling)

--- a/markymark/Classes/MarkDown Items/CodeBlockMarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/CodeBlockMarkDownItem.swift
@@ -7,7 +7,7 @@ import Foundation
 
 open class CodeBlockMarkDownItem: MarkDownItem {
 
-    override func allowsChildMarkDownItems() -> Bool {
+    override open func allowsChildMarkDownItems() -> Bool {
         return false
     }
 }

--- a/markymark/Classes/MarkDown Items/InlineCodeMarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/InlineCodeMarkDownItem.swift
@@ -7,7 +7,7 @@ import Foundation
 
 open class InlineCodeMarkDownItem: MarkDownItem {
 
-    override func allowsChildMarkDownItems() -> Bool {
+    override open func allowsChildMarkDownItems() -> Bool {
         return false
     }
 }

--- a/markymark/Classes/MarkDown Items/InlineTextMarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/InlineTextMarkDownItem.swift
@@ -7,7 +7,7 @@ import Foundation
 
 open class InlineTextMarkDownItem: MarkDownItem {
 
-    override func allowsChildMarkDownItems() -> Bool {
+    override open func allowsChildMarkDownItems() -> Bool {
         return false
     }
 }

--- a/markymark/Classes/MarkDown Items/LinkMarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/LinkMarkDownItem.swift
@@ -17,4 +17,8 @@ open class LinkMarkDownItem: MarkDownItem {
     required public init(lines: [String], content: String) {
         fatalError("init(lines:content:) has not been implemented")
     }
+
+    override open func allowsChildMarkDownItems() -> Bool {
+        false
+    }
 }

--- a/markymark/Classes/MarkDown Items/MarkDownItem.swift
+++ b/markymark/Classes/MarkDown Items/MarkDownItem.swift
@@ -17,7 +17,7 @@ open class MarkDownItem {
         self.lines = lines
     }
 
-    func allowsChildMarkDownItems() -> Bool {
+    open func allowsChildMarkDownItems() -> Bool {
         return true
     }
 }

--- a/markymark/Classes/MarkyMark.swift
+++ b/markymark/Classes/MarkyMark.swift
@@ -16,6 +16,9 @@ open class MarkyMark {
     /// Default rule to use if no other rule can be applied
     var defaultRule: Rule?
 
+    /// Array of rules to apply on top of the rules of the Flavor
+    var additionalInlineRules: [InlineRule] = []
+
     /// Default inline rule to use if no other rule can be applied
     var defaultInlineRule: InlineRule?
 
@@ -102,6 +105,16 @@ open class MarkyMark {
 
     open func addRule(_ rule: Rule) {
         additionalRules.append(rule)
+    }
+
+    /**
+     Adds a Markdown rule that will be used to recognize Markdown syntax
+
+     - parameter rule: InlineRule that can recoginize markdown syntax
+     */
+
+    open func addInlineRule(_ rule: InlineRule) {
+        additionalInlineRules.append(rule)
     }
 
     /**
@@ -205,7 +218,13 @@ open class MarkyMark {
     }
 
     func allInlineRules() -> [InlineRule] {
-        return flavor?.inlineRules ?? []
+        var rules = self.additionalInlineRules
+
+        if let flavor = flavor {
+            rules += flavor.inlineRules
+        }
+
+        return rules
     }
 
     /**

--- a/markymark/Classes/Protocols/CanSetURLOpener.swift
+++ b/markymark/Classes/Protocols/CanSetURLOpener.swift
@@ -5,6 +5,6 @@
 
 import Foundation
 
-protocol CanSetURLOpener {
+public protocol CanSetURLOpener {
     func set(urlOpener: URLOpener?)
 }

--- a/markymark/Classes/Protocols/MarkDownView.swift
+++ b/markymark/Classes/Protocols/MarkDownView.swift
@@ -1,0 +1,15 @@
+//
+//  MarkDownView.swift
+//  Pods
+//
+//  Created by Jim van Zummeren on 21/03/2022.
+//
+
+import Foundation
+
+protocol MarkDownView: UIView {
+    var text: String? { get set }
+    var styling: DefaultStyling { get set }
+    func add(rule: Rule)
+    func add(inlineRule: InlineRule)
+}

--- a/markymark/Classes/Renderer/Configurations/MarkDownToAttributedStringConverterConfiguration.swift
+++ b/markymark/Classes/Renderer/Configurations/MarkDownToAttributedStringConverterConfiguration.swift
@@ -11,11 +11,14 @@ import UIKit
 
 open class MarkDownToAttributedStringConverterConfiguration: MarkDownConverterConfiguration<NSMutableAttributedString> {
 
-    public override init(elementComposer: ElementComposer<NSMutableAttributedString>, styling: Styling) {
+    private let inlineConverter: MarkDownConverterConfiguration<NSMutableAttributedString>
 
+    public override init(elementComposer: ElementComposer<NSMutableAttributedString>, styling: Styling) {
+        inlineConverter = MarkDownToInlineAttributedStringConverterConfiguration(styling: styling)
         super.init(elementComposer: elementComposer, styling: styling)
 
-        let converter = MarkDownConverter(configuration: MarkDownToInlineAttributedStringConverterConfiguration(styling: styling))
+
+        let converter = MarkDownConverter(configuration: inlineConverter)
 
         addLayoutBlockBuilder(HeaderAttributedStringLayoutBlockBuilder(converter: converter))
         addLayoutBlockBuilder(ParagraphAttributedStringLayoutBlockBuilder(converter: converter))
@@ -29,5 +32,9 @@ open class MarkDownToAttributedStringConverterConfiguration: MarkDownConverterCo
 
     public convenience init(styling: Styling) {
         self.init(elementComposer: AttributedStringComposer(), styling: styling)
+    }
+
+    open func addInlineLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString>) {
+        inlineConverter.addLayoutBlockBuilder(layoutBlockBuilder)
     }
 }

--- a/markymark/Classes/Renderer/Configurations/MarkdownToViewConverterConfiguration.swift
+++ b/markymark/Classes/Renderer/Configurations/MarkdownToViewConverterConfiguration.swift
@@ -16,12 +16,15 @@ open class MarkdownToViewConverterConfiguration: MarkDownConverterConfiguration<
         }
     }
 
+    private let inlineConverter: MarkDownConverterConfiguration<NSMutableAttributedString>
+
     public init(elementComposer: ElementComposer<UIView>, styling: Styling, urlOpener: URLOpener? = nil) {
         self.urlOpener = urlOpener
-        
+
+        inlineConverter = MarkDownToInlineAttributedStringConverterConfiguration(styling: styling)
         super.init(elementComposer: elementComposer, styling: styling)
 
-        let converter = MarkDownConverter(configuration: MarkDownToInlineAttributedStringConverterConfiguration(styling: styling))
+        let converter = MarkDownConverter(configuration: inlineConverter)
 
         addLayoutBlockBuilder(HeaderViewLayoutBlockBuilder(converter: converter))
         addLayoutBlockBuilder(ParagraphViewLayoutBlockBuilder(converter: converter))
@@ -41,6 +44,10 @@ open class MarkdownToViewConverterConfiguration: MarkDownConverterConfiguration<
     override open func addLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<UIView>) {
         super.addLayoutBlockBuilder(layoutBlockBuilder)
         setUrlOpenerIfPossible(layoutBlockBuilder)
+    }
+
+    open func addInlineLayoutBlockBuilder(_ layoutBlockBuilder: LayoutBlockBuilder<NSMutableAttributedString>) {
+        inlineConverter.addLayoutBlockBuilder(layoutBlockBuilder)
     }
 }
 

--- a/markymark/Classes/Rules/Inline/ImageRule.swift
+++ b/markymark/Classes/Rules/Inline/ImageRule.swift
@@ -12,7 +12,7 @@ open class ImageRule: InlineRegexRule {
     /// Example: ![Alt text](image.png)
     public var expression = NSRegularExpression.expressionWithPattern("!\\[([^]]*)\\]\\(([^]]+?)\\)")
 
-    public func createMarkDownItemWithLines(_ lines: [String]) -> MarkDownItem {
+    open func createMarkDownItemWithLines(_ lines: [String]) -> MarkDownItem {
 
         let file: String? =  lines.first?.subStringWithExpression(expression, ofGroup: 2)
         let altText: String? =  lines.first?.subStringWithExpression(expression, ofGroup: 1)


### PR DESCRIPTION
## Allow adding inline rules and inline layout builders to MarkdownTextView

- Made sure all layout builders are open classes
- Allow overriding allowsChildMarkDownItems of rules
- Refactor MarkdownTextView to have either a MarkdownViewTextView or MarkdownAttributedStringTextView and removed the existing solution