### PR TITLE
Fixed issue with large line-height when setting a max font-size on li…

### DIFF
--- a/markymark.podspec
+++ b/markymark.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "markymark"
-  s.version          = "11.0.0"
+  s.version          = "11.0.1"
   s.summary          = "Markdown parser for iOS"
   s.description      = <<-DESC
 Marky Mark is a parser written in Swift that converts markdown into native views. The way it looks is highly customizable and the supported markdown syntax and tags are easy to extend.

--- a/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ListViewLayoutBlockBuilder.swift
+++ b/markymark/Classes/Layout Builders/UIView/Block Builders/Block/ListViewLayoutBlockBuilder.swift
@@ -90,12 +90,11 @@ class ListViewLayoutBlockBuilder: InlineAttributedStringViewLayoutBlockBuilder {
     ) -> CGFloat {
         let space = listStyling?.bottomListItemSpacing ?? 0
 
-        if renderContext.hasScalableFonts == true, let textStyle = listStyling?.neededTextStyle() {
-            let fontMetrics = UIFontMetrics(forTextStyle: textStyle)
-            return fontMetrics.scaledValue(for: space)
-        } else {
-            return space
-        }
+        let hasScalableFonts = renderContext.hasScalableFonts == true
+
+        let scaleFactor = listStyling?.scaleFactor(hasScalableFonts: hasScalableFonts) ?? 1
+
+        return space * scaleFactor
     }
 
 }

--- a/markymark/Classes/Layout Builders/UIView/Views/ListItemView.swift
+++ b/markymark/Classes/Layout Builders/UIView/Views/ListItemView.swift
@@ -69,20 +69,14 @@ class ListItemView: UIView {
         guard let styling = styling else { return nil }
         let hasScalableFonts = renderContext?.hasScalableFonts == true
 
-        if
-            hasScalableFonts,
-            let originalPointSize = styling.neededBaseFont()?.pointSize,
-            let newPointSize = styling.neededFont(hasScalableFonts: hasScalableFonts)?.pointSize
-        {
-            let scaleFactor = newPointSize / originalPointSize
+        let scaleFactor = styling.scaleFactor(
+            hasScalableFonts: hasScalableFonts
+        )
 
-            return .init(
-                width: styling.bulletViewSize.width * scaleFactor,
-                height: styling.bulletViewSize.height * scaleFactor
-            )
-        } else {
-            return styling.bulletViewSize
-        }
+        return .init(
+            width: styling.bulletViewSize.width * scaleFactor,
+            height: styling.bulletViewSize.height * scaleFactor
+        )
     }
 
     // MARK: Private

--- a/markymark/Classes/Styling/Protocols/BaseFontStylingRule.swift
+++ b/markymark/Classes/Styling/Protocols/BaseFontStylingRule.swift
@@ -79,6 +79,20 @@ extension ItemStyling {
             return font
         }
     }
+
+    func scaleFactor(hasScalableFonts: Bool) -> CGFloat {
+        if
+            hasScalableFonts,
+            let originalPointSize = neededBaseFont()?.pointSize,
+            let newPointSize = neededFont(hasScalableFonts: hasScalableFonts)?.pointSize
+        {
+            let scaleFactor = newPointSize / originalPointSize
+
+            return scaleFactor
+        } else {
+            return 1
+        }
+    }
 }
 
 private extension UIFont {


### PR DESCRIPTION
When using `UIFontMetrics(forTextStyle: textStyle).scaledValue(for:)`, you cannot take a configured maximumFontSize of Dynamic type into account. In this case, causing the spacing between list-items to continue to grow, while the font-size is not longer growing (reached max font-size). In order to solve this, we manually calculate the scaleFactor by dividing the orignal font-size with the current font-size.